### PR TITLE
Configure the SOAP client to always return an array for a sequence

### DIFF
--- a/AvaTax/DynamicSoapClient.php
+++ b/AvaTax/DynamicSoapClient.php
@@ -23,6 +23,13 @@ class DynamicSoapClient extends \SoapClient
     private $config;
     public function __construct($wsdl,$options,&$config)
     {
+        /**
+         * Ensure we get back an array any time there is a XML sequence
+         *
+         * @see https://bugs.php.net/bug.php?id=36226
+         */
+        $options['features'] = ((isset($options['features']) ? $options['features'] : 0) | SOAP_SINGLE_ELEMENT_ARRAYS);
+        
         parent::__construct($wsdl,$options);
         $this->config = $config; 
     }


### PR DESCRIPTION
PHPs SOAP client has inconsistent default behaviour. If you receive a single element sequence, the client will set the property to the sequence member. If you have multiple sequence elements the property is an array of members instead. This is why Utils::EnsureIsArray() is used in the AvaTax code to 'fix' the problem. The better fix is to use the feature flag that turns on the correct behaviour of always returning an array for a sequence.
