### PR TITLE
Remove unused argument from getTaxIncluded

### DIFF
--- a/AvaTax/Line.php
+++ b/AvaTax/Line.php
@@ -201,7 +201,7 @@ class Line
 	 * True if tax is included in the line.
 	 * @return boolean	 
 	 */
-	public function getTaxIncluded($value)
+	public function getTaxIncluded()
 	{
 		return $this->TaxIncluded;
     }


### PR DESCRIPTION
This pull request removes an unused argument from `getTaxIncluded`