### PR TITLE
Allow Accepting SoapClient Options

### DIFF
--- a/AvaTax/TaxServiceSoap.php
+++ b/AvaTax/TaxServiceSoap.php
@@ -58,16 +58,17 @@ class TaxServiceSoap extends AvalaraSoapClient {
         'TaxOverride' => 'AvaTax\TaxOverride'
     );
 
-    public function __construct($configurationName = 'Default') {
+    public function __construct($configurationName = 'Default', $options = array()) {
         $config = new ATConfig($configurationName);
 
         $this->client = new DynamicSoapClient(
-                $config->taxWSDL, array
-            (
-            'location' => $config->url . $config->taxService,
-            'trace' => $config->trace,
-            'classmap' => TaxServiceSoap::$classmap
-                ), $config
+            $config->taxWSDL,
+            array_merge($options, array(
+                'location' => $config->url . $config->taxService,
+                'trace' => $config->trace,
+                'classmap' => TaxServiceSoap::$classmap
+            )),
+            $config
         );
     }
 


### PR DESCRIPTION
Sometimes we need to modify `SoapClient` options, such as `connection_timeout`. This change will allow for such a modification.